### PR TITLE
Avoid locking on scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ The `aws-health-exporter` exports just one metric (event count) and you want to 
 Example
 ```
 # This gives us a list of all `open` events in region `us-east-1` of type `issue`
-aws_health_event_count{status_code="open", region="us-east-1", category="issue"}
+aws_health_events{status_code="open", region="us-east-1", category="issue"}
 ```
 
 Name | Description | Labels
 -----|-----|-----
-aws_health_event_count | AWS Health event counter | category, region, service, status_code
+aws_health_events | AWS Health events | category, region, service, status_code
 
 ### Labels Explained
 Label | Description

--- a/aws_health_exporter.go
+++ b/aws_health_exporter.go
@@ -46,9 +46,9 @@ var (
 	// labels are the static labels that come with every metric
 	labels = []string{LabelCategory, LabelRegion, LabelService, LabelStatusCode}
 
-	// event_count is the number of aws health events reported
+	// events is the number of aws health events reported
 	eventOpts = prometheus.GaugeOpts{
-		Name:      "event_count",
+		Name:      "events",
 		Namespace: Namespace,
 		Help:      "Gauge for aws health events",
 	}

--- a/aws_health_exporter_test.go
+++ b/aws_health_exporter_test.go
@@ -59,11 +59,12 @@ func TestScrape(t *testing.T) {
 		filter: &health.EventFilter{},
 	}
 
-	e.scrape()
+	gv := prometheus.NewGaugeVec(eventOpts, labels)
+	e.scrape(gv)
 
-	validateMetric(t, eventCount, events[0], 1.)
-	validateMetric(t, eventCount, events[1], 1.)
-	validateMetric(t, eventCount, events[2], 3.)
+	validateMetric(t, gv, events[0], 1.)
+	validateMetric(t, gv, events[1], 1.)
+	validateMetric(t, gv, events[2], 3.)
 }
 
 func validateMetric(t *testing.T, vec *prometheus.GaugeVec, e *health.Event, expectedVal float64) {


### PR DESCRIPTION
We now create one GaugeVec for each scrape so we can avoid the locking. 

Additionally as a minor change the metric is now called `events` instead of `event_count` as the `_count` suffix should only be used for histogram or summaries.

These changes are based on the feedback from: https://github.com/prometheus/docs/pull/828