### PR TITLE
Use SOURCE_COMMIT from docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:alpine
 
-ARG VERSION
-ARG DATE
+ARG SOURCE_COMMIT
 
 ADD . /go/src/github.com/Jimdo/aws-health-exporter
 WORKDIR /go/src/github.com/Jimdo/aws-health-exporter
 
-RUN go install -ldflags="-X 'main.Version=${VERSION}' -X 'main.BuildTime=${DATE}'" ./...
+RUN DATE=$(date -u '+%Y-%m-%d-%H%M UTC'); \
+    go install -ldflags="-X 'main.Version=${SOURCE_COMMIT}' -X 'main.BuildTime=${DATE}'" ./...
 
 ENTRYPOINT  [ "/go/bin/aws-health-exporter" ]
 EXPOSE      9383

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-DATE 		= $(shell date -u '+%Y-%m-%d-%H%M UTC')
 IMAGE 		?= aws-health-exporter
 VERSION 	= $(shell git describe --always --tags --dirty)
 GO_PACKAGES = $(shell go list ./... | grep -v /vendor/)
@@ -20,8 +19,7 @@ build:
 docker:
 	@echo ">> building docker image"
 	@docker build \
-		--build-arg VERSION="$(VERSION)" \
-		--build-arg DATE="$(DATE)" \
+		--build-arg SOURCE_COMMIT="$(VERSION)" \
 		-t $(IMAGE):$(VERSION) \
 		.
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest


### PR DESCRIPTION
Use the SOURCE_COMMIT provided by dockerhub to inject the build-args.